### PR TITLE
保留中文之外的字符

### DIFF
--- a/Dockerfile.webhook
+++ b/Dockerfile.webhook
@@ -3,27 +3,31 @@ FROM phusion/baseimage:jammy-1.0.1
 WORKDIR /usr/src/emby_pinyin
 
 COPY --from=composer:lts /usr/bin/composer /usr/bin/composer
-COPY . /usr/src/emby_pinyin
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN touch /root/.vimrc && \
+    sed -i 's/http:\/\/archive.ubuntu.com/http:\/\/mirrors.aliyun.com/g' /etc/apt/sources.list && \
+    sed -i 's/http:\/\/security.ubuntu.com/http:\/\/mirrors.aliyun.com/g' /etc/apt/sources.list && \
+    apt update && \
+    apt install php php-dev php-curl php-json php-mbstring php-zip -y  && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 COPY build/service/ /etc/service/
 COPY build/cron/ /etc/cron.d/
 COPY build/init/ /etc/my_init.d/
 
-ENV DEBIAN_FRONTEND=noninteractive
 ENV PHP_INI_DIR=/etc/php/8.1/cli
+
+COPY . /usr/src/emby_pinyin
+
+RUN sed -i 's|;phar.readonly = On|phar.readonly = Off|' $PHP_INI_DIR/php.ini && \
+    composer pre-install
+
 ENV WEBHOOK_ENABLED=0
 ENV CRON_ENABLED=0
 ENV CRON_SCHEDULE="0 * * * *"
 ENV HOST="http://example:8096"
 ENV API_KEY="*****"
 ENV SORT_TYPE=1
-
-RUN touch /root/.vimrc && \
-    sed -i 's/http:\/\/archive.ubuntu.com/http:\/\/mirrors.aliyun.com/g' /etc/apt/sources.list && \
-    sed -i 's/http:\/\/security.ubuntu.com/http:\/\/mirrors.aliyun.com/g' /etc/apt/sources.list && \
-    apt update && \
-    apt install php php-dev php-curl php-json php-mbstring php-zip -y  && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    sed -i 's|;phar.readonly = On|phar.readonly = Off|' $PHP_INI_DIR/php.ini && \
-    composer pre-install
 
 EXPOSE 80


### PR DESCRIPTION
由于原来的方案会丢弃非中文字符，所以可能会造成一定程度的排序问题。
比如`"こどもじゃず そ"`和`"こどもじゃず その2"`会变成`""`和`"2"`，排序会变为一个跑到最后面另一个跑到最前面。符合预期的结果应当是挨在一起。

我的修改使其保留了中文、英文、数字之外的其他字符，在排序的使用场景可以给出更好的结果。

请根据您的需求酌情拉取代码，如果觉得不适合这个项目，或者有更好的方法，也可以不使用我提供的代码。